### PR TITLE
Ensure paths exist

### DIFF
--- a/newsthreads/__init__.py
+++ b/newsthreads/__init__.py
@@ -5,7 +5,8 @@ from .combinedClusterLabels import combine_cluster_labels
 from .sentences import process_sentences
 from .domain_dependency_graph import domain_dependency_graph
 from .build_hierarchy import build_hierarchy
+from .paths import ensure_paths_exist
 
 __all__ = ["get_common_config", "get_dataset_config", "get_epsilon_cluster_filename", "get_logger", "build_minhash",
            "calculate_jaccard", "perform_dbscan", "combine_cluster_labels", "process_sentences",
-           "domain_dependency_graph", "build_hierarchy"]
+           "domain_dependency_graph", "build_hierarchy", "ensure_paths_exist"]

--- a/newsthreads/__main__.py
+++ b/newsthreads/__main__.py
@@ -1,11 +1,14 @@
 from . import get_dataset_config, build_minhash, calculate_jaccard, perform_dbscan, combine_cluster_labels, \
-    process_sentences, domain_dependency_graph, build_hierarchy
+    process_sentences, domain_dependency_graph, build_hierarchy, ensure_paths_exist
 import configparser
 import locale
 
 config: configparser.SectionProxy = get_dataset_config()
 
 locale.setlocale(locale.LC_ALL, '')  # Set locale so we get separators in numeric number formats
+
+# Make sure the output paths exist
+ensure_paths_exist(config)
 
 (id_list, arryHash) = build_minhash(config)
 calculate_jaccard(config, id_list, arryHash)

--- a/newsthreads/paths.py
+++ b/newsthreads/paths.py
@@ -5,6 +5,7 @@ from . import get_logger
 
 logger = get_logger(os.path.basename(__file__))
 
+
 def ensure_paths_exist(config: configparser.SectionProxy):
     """Ensures that input data and output paths exist"""
     output_path = config['OutputPath']
@@ -16,7 +17,7 @@ def ensure_paths_exist(config: configparser.SectionProxy):
     if not os.path.exists(output_path):
         logger.info(f"Creating path {output_path}")
         os.makedirs(output_path)
-    
+
     if not os.path.exists(input_file):
         logger.error(f"Input file {input_file} does not exist")
-        sys.exit(1) # Force interpreter to exit after error message above
+        sys.exit(1)  # Force interpreter to exit after error message above

--- a/newsthreads/paths.py
+++ b/newsthreads/paths.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import configparser
+from . import get_logger
+
+logger = get_logger(os.path.basename(__file__))
+
+def ensure_paths_exist(config: configparser.SectionProxy):
+    """Ensures that input data and output paths exist"""
+    output_path = config['OutputPath']
+    intermediate_path = config['IntermediatePath']
+    input_file = config['InputDocumentFileName']
+    if not os.path.exists(intermediate_path):
+        logger.info(f"Creating path {intermediate_path}")
+        os.makedirs(intermediate_path)
+    if not os.path.exists(output_path):
+        logger.info(f"Creating path {output_path}")
+        os.makedirs(output_path)
+    
+    if not os.path.exists(input_file):
+        logger.error(f"Input file {input_file} does not exist")
+        sys.exit(1) # Force interpreter to exit after error message above


### PR DESCRIPTION
Ensures that the input exists.  If output paths do not exist then they are created.  The purpose of this PR is to give nicer error messages when the application is configured incorrectly.